### PR TITLE
Minor fix to dropout layer

### DIFF
--- a/retain.py
+++ b/retain.py
@@ -84,7 +84,8 @@ def init_tparams(params, options):
 	return tparams
 
 def dropout_layer(state_before, use_noise, trng, dropout_rate=0.5):
-	proj = T.switch(use_noise, (state_before * trng.binomial(state_before.shape, p=dropout_rate, n=1, dtype=state_before.dtype)), state_before * 0.5)
+	proj = T.switch(use_noise, (state_before * trng.binomial(state_before.shape, p=dropout_rate, n=1, dtype=state_before.dtype)), 
+state_before / dropout_rate)
 	return proj
 
 def _slice(_x, n, dim):


### PR DESCRIPTION
Normalization of dropout at test time was hardcoded to 0.5.  Fixed to scale correctly with dropout_rate.

No difference in behavior with a dropout of 0.5, and probably only a minor effect with other dropout values, but I saw it so I figured I'd propose the fix.